### PR TITLE
Replaces root element after patching

### DIFF
--- a/src/DOM/Virtual.purs
+++ b/src/DOM/Virtual.purs
@@ -25,7 +25,7 @@ type Attributes = Array Attribute
 
 foreign import diff :: VTree -> VTree -> Diff
 foreign import createElement :: VTree -> Effect Element
-foreign import patchElement :: Diff -> Element -> Effect Unit
+foreign import patchElement :: Diff -> Element -> Effect Element
 
 foreign import node :: String
                     -> Attributes

--- a/src/DOM/Virtual/App.purs
+++ b/src/DOM/Virtual/App.purs
@@ -69,8 +69,8 @@ rerenderApp newTree (App domRef) = do
 
   let patches = diff domState.tree newTree
 
-  Ref.write (domState { tree = newTree }) domRef
-  patchElement patches domState.elem
+  newRoot <- patchElement patches domState.elem
+  Ref.write { tree: newTree, elem: newRoot } domRef
 
 -- Function aliases to sort out the effect types
 -- of the actors involved


### PR DESCRIPTION
virtual-dom's patchElement function returns a new root element that we
had been discarding. By discarding this we were running the risk of
having our subsequent patch operations be applied to the wrong element.
Historically, we sidestepped this problem by our root element always
being reusable by later patch operations because in most cases
virtual-dom was able to return the same root element.

We now keep track of any root element changes coming out of
`patchElement` inside of the Erumu App state.

Co-authored-by: David <david@flipstone.com>
