### PR TITLE
Add nonMultipleClick handler

### DIFF
--- a/src/DOM/Erumu/HTML/Events.purs
+++ b/src/DOM/Erumu/HTML/Events.purs
@@ -8,12 +8,16 @@ module DOM.Erumu.HTML.Events
   , onfocus
   , onmouseenter
   , onmouseleave
+  , onNonMultipleClick
   ) where
 
-import DOM.Erumu.Types (onEvent, onPreventDefaultEvent, onPropagatingEvent, Prop)
+import DOM.Erumu.Types (Prop, onEvent, onPreventDefaultEvent, onPropagatingEvent, onPropagatingNonMultiplePointerEvent)
 
 onclick :: forall msg. msg -> Prop msg
 onclick = onPropagatingEvent "onclick"
+
+onNonMultipleClick :: forall msg. msg -> Prop msg
+onNonMultipleClick = onPropagatingNonMultiplePointerEvent "onclick"
 
 terminalOnclick :: forall msg. msg -> Prop msg
 terminalOnclick = onEvent "onclick"

--- a/src/DOM/Erumu/Types.purs
+++ b/src/DOM/Erumu/Types.purs
@@ -35,6 +35,7 @@ module DOM.Erumu.Types
   , onEvent
   , onPreventDefaultEvent
   , onPropagatingEvent
+  , onPropagatingNonMultiplePointerEvent
   , onEventDecode
   , onEventMaybeDecode
 
@@ -62,7 +63,7 @@ import Effect (Effect)
 import DOM.Erumu.Decode (Decode)
 import DOM.Erumu.Decode as Decode
 import Web.Event.Event (Event)
-import DOM.Virtual (VTree, Attribute, EventHandler, node, stringValue, nonPropagatingEventHandler, preventDefaultEventHandler, propagatingEventHandler)
+import DOM.Virtual (Attribute, EventHandler, VTree, node, nonPropagatingEventHandler, preventDefaultEventHandler, propagatingEventHandler, propagatingNonMultiplePointerEventHandler, stringValue)
 import DOM.Virtual as Virtual
 
 --not sure about this. I actually think VTree shouldn't have a type parameter. I certainly don't want to add one for `HTML`. Maybe it should just be concrete.
@@ -366,6 +367,12 @@ onPropagatingEvent :: forall msg. String -> msg -> Prop msg
 onPropagatingEvent name dat =
   handlerProp name
     propagatingEventHandler
+    (\_ -> pure [ dat ])
+
+onPropagatingNonMultiplePointerEvent :: forall msg. String -> msg -> Prop msg
+onPropagatingNonMultiplePointerEvent name dat =
+  handlerProp name
+    propagatingNonMultiplePointerEventHandler
     (\_ -> pure [ dat ])
 
 onPreventDefaultEvent :: forall msg. String -> msg -> Prop msg

--- a/src/DOM/Virtual.js
+++ b/src/DOM/Virtual.js
@@ -70,6 +70,17 @@ export function node(name) {
   }
 }
 
+// Handles only 0 clicks (keyboard)
+// and single mouse clicks
+export function propagatingNonMultiplePointerEventHandler(eff) {
+  return function(event) {
+    if (!(event instanceof PointerEvent) || event.detail > 1) {
+      return;
+    }
+    eff(event)();
+  }
+}
+
 export function nonPropagatingEventHandler(eff) {
   return function(event) {
     eff(event)();

--- a/src/DOM/Virtual.purs
+++ b/src/DOM/Virtual.purs
@@ -22,6 +22,7 @@ module DOM.Virtual
   , preventDefaultEventHandler
   , propagatingEventHandler
   , nonPropagatingEventHandler
+  , propagatingNonMultiplePointerEventHandler
   ) where
 
 import Prelude
@@ -57,6 +58,7 @@ foreign import unsafeValue :: forall v. v -> Value
 --
 type EventHandler = (Event -> Effect Unit) -> Value
 
+foreign import propagatingNonMultiplePointerEventHandler :: EventHandler
 foreign import nonPropagatingEventHandler :: EventHandler
 foreign import propagatingEventHandler :: EventHandler
 foreign import preventDefaultEventHandler :: EventHandler


### PR DESCRIPTION
When making an application, occasionally it is convenient to distinguish
between single clicks, double clicks and triple clicks.

The user may have configured their operating system to use a non-standard
double click configuration.

By accessing the browsers' click counter, we respect the user's accessibility
configuration.

As an alternative to this PR, one can implement similar behaviour by creating
Erumu events for each click and in the handler checking if the last event was
very recent.

This has a couple of disadvantages however:
* It's a reimplementation of information that the browser already gives us on the
  PointerEvent. As such, it feels like it shouldn't be necessary.
* The interval between clicks may disagree with the OS setting, confusing users
  that have heightened the OS configured interval.

By making this part of Erumu we avoid having to reimplement the same logic in the
browser.

A keyboard click is also a PointerEvent. This is unintuitive but easily
confirmed in [the onclick JavaScript playground](https://www.w3schools.com/jsref/tryit.asp?filename=tryjsref_event_mouse_detail).
