### PR TITLE
[sc-40050] Add missing HTML elements and attributes

### DIFF
--- a/src/DOM/Erumu/HTML/Attributes.purs
+++ b/src/DOM/Erumu/HTML/Attributes.purs
@@ -1,16 +1,58 @@
 module DOM.Erumu.HTML.Attributes
-  ( action
+  ( accept
+  , action
   , alt
+  , ariaActivedescendant
+  , ariaAtomic
+  , ariaAutocomplete
+  , ariaBraillelabel
+  , ariaBrailleroledescription
+  , ariaBusy
+  , ariaChecked
+  , ariaColcount
+  , ariaColindex
+  , ariaColindextext
+  , ariaColspan
   , ariaControls
+  , ariaCurrent
   , ariaDescribedby
+  , ariaDescription
+  , ariaDetails
+  , ariaDisabled
+  , ariaErrormessage
   , ariaExpanded
+  , ariaFlowto
   , ariaHaspopup
   , ariaHidden
   , ariaInvalid
+  , ariaKeyshortcuts
+  , ariaLabel
   , ariaLabelledby
+  , ariaLevel
   , ariaLive
   , ariaModal
+  , ariaMultiline
+  , ariaMultiselectable
   , ariaOrientation
+  , ariaOwns
+  , ariaPlaceholder
+  , ariaPosinset
+  , ariaPressed
+  , ariaReadonly
+  , ariaRelevant
+  , ariaRequired
+  , ariaRoledescription
+  , ariaRowcount
+  , ariaRowindex
+  , ariaRowindextext
+  , ariaRowspan
+  , ariaSelected
+  , ariaSetsize
+  , ariaSort
+  , ariaValuemax
+  , ariaValuemin
+  , ariaValuenow
+  , ariaValuetext
   , autocomplete
   , autofocus
   , cRadius
@@ -20,14 +62,23 @@ module DOM.Erumu.HTML.Attributes
   , classes
   , clipRule
   , colSpan
+  , contenteditable
+  , crossorigin
   , cxCoord
   , cyCoord
+  , dataCustom
   , data_
   , defaultValue
   , defer
   , dims
+  , dir
+  , dirname
   , disabled
+  , draggable
+  , elementtiming
   , enctype
+  , enterkeyhint
+  , exportparts
   , fill
   , fillRule
   , fontFamily
@@ -35,21 +86,44 @@ module DOM.Erumu.HTML.Attributes
   , for
   , gradientUnits
   , height
+  , hidden
   , href
   , id_
+  , inert
+  , inputmode
+  , itemid
+  , itemprop
+  , itemref
+  , itemscope
+  , itemtype
+  , lang
+  , max
+  , maxlength
   , method
+  , min
+  , minlength
+  , multiple
   , name
+  , nonce
   , noop
   , offset
+  , part
+  , pattern
   , placeholder
   , points
+  , popover
+  , popovertarget
+  , readonly
   , required
   , role
   , rows
   , rx
   , selected
+  , size
+  , slot
   , spellcheck
   , src
+  , step
   , stroke
   , strokeLinecap
   , strokeLinejoin
@@ -59,10 +133,12 @@ module DOM.Erumu.HTML.Attributes
   , target
   , title
   , transform
+  , translate
   , type_
   , value
   , viewBox
   , width
+  , writingsuggestions
   , x1Coord
   , x2Coord
   , xCoord
@@ -73,9 +149,9 @@ module DOM.Erumu.HTML.Attributes
   ) where
 
 import Prelude
-import Data.String (joinWith)
 
 import DOM.Erumu.Types (attribute, Prop)
+import Data.String (joinWith)
 
 action :: forall msg. String -> Prop msg
 action = attribute "action"
@@ -83,35 +159,169 @@ action = attribute "action"
 alt :: forall msg. String -> Prop msg
 alt = attribute "alt"
 
+-- ARIA attributes
+
+ariaAttribute :: forall msg. String -> String -> Prop msg
+ariaAttribute key ariaValue =
+  attribute ("aria-" <> key) ariaValue
+
+ariaActivedescendant :: forall msg. String -> Prop msg
+ariaActivedescendant = ariaAttribute "activedescendant"
+
+ariaAtomic :: forall msg. Boolean -> Prop msg
+ariaAtomic = ariaAttribute "atomic" <<< show
+
+ariaAutocomplete :: forall msg. String -> Prop msg
+ariaAutocomplete = ariaAttribute "autocomplete"
+
+ariaBraillelabel :: forall msg. String -> Prop msg
+ariaBraillelabel = ariaAttribute "braillelabel"
+
+ariaBrailleroledescription :: forall msg. String -> Prop msg
+ariaBrailleroledescription = ariaAttribute "brailleroledescription"
+
+ariaBusy :: forall msg. Boolean -> Prop msg
+ariaBusy = ariaAttribute "busy" <<< show
+
+ariaChecked :: forall msg. Boolean -> Prop msg
+ariaChecked = ariaAttribute "checked" <<< show
+
+ariaColcount :: forall msg. Int -> Prop msg
+ariaColcount = ariaAttribute "colcount" <<< show
+
+ariaColindex :: forall msg. Int -> Prop msg
+ariaColindex = ariaAttribute "colindex" <<< show
+
+ariaColindextext :: forall msg. String -> Prop msg
+ariaColindextext = ariaAttribute "colindextext"
+
+ariaColspan :: forall msg. Int -> Prop msg
+ariaColspan = ariaAttribute "colspan" <<< show
+
 ariaControls :: forall msg. String -> Prop msg
-ariaControls = attribute "aria-controls"
+ariaControls = ariaAttribute "controls"
+
+ariaCurrent :: forall msg. String -> Prop msg
+ariaCurrent = ariaAttribute "current"
 
 ariaDescribedby :: forall msg. String -> Prop msg
-ariaDescribedby = attribute "aria-describedby"
+ariaDescribedby = ariaAttribute "describedby"
+
+ariaDescription :: forall msg. String -> Prop msg
+ariaDescription = ariaAttribute "description"
+
+ariaDetails :: forall msg. String -> Prop msg
+ariaDetails = ariaAttribute "details"
+
+ariaDisabled :: forall msg. Boolean -> Prop msg
+ariaDisabled = ariaAttribute "disabled" <<< show
+
+ariaErrormessage :: forall msg. String -> Prop msg
+ariaErrormessage = ariaAttribute "errormessage"
 
 ariaExpanded :: forall msg. Boolean -> Prop msg
-ariaExpanded = attribute "aria-expanded" <<< show
+ariaExpanded = ariaAttribute "expanded" <<< show
+
+ariaFlowto :: forall msg. String -> Prop msg
+ariaFlowto = ariaAttribute "flowto"
 
 ariaHaspopup :: forall msg. Boolean -> Prop msg
-ariaHaspopup = attribute "aria-haspopup" <<< show
+ariaHaspopup = ariaAttribute "haspopup" <<< show
 
 ariaHidden :: forall msg. Boolean -> Prop msg
-ariaHidden = attribute "aria-hidden" <<< show
+ariaHidden = ariaAttribute "hidden" <<< show
 
 ariaInvalid :: forall msg. Boolean -> Prop msg
-ariaInvalid = attribute "aria-invalid" <<< show
+ariaInvalid = ariaAttribute "invalid" <<< show
+
+ariaKeyshortcuts :: forall msg. String -> Prop msg
+ariaKeyshortcuts = ariaAttribute "keyshortcuts"
+
+ariaLabel :: forall msg. String -> Prop msg
+ariaLabel = ariaAttribute "label"
 
 ariaLabelledby :: forall msg. String -> Prop msg
-ariaLabelledby = attribute "aria-labelledby"
+ariaLabelledby = ariaAttribute "labelledby"
+
+ariaLevel :: forall msg. Int -> Prop msg
+ariaLevel = ariaAttribute "level" <<< show
 
 ariaLive :: forall msg. String -> Prop msg
-ariaLive = attribute "aria-live"
+ariaLive = ariaAttribute "live"
 
 ariaModal :: forall msg. Boolean -> Prop msg
-ariaModal = attribute "aria-modal" <<< show
+ariaModal = ariaAttribute "modal" <<< show
+
+ariaMultiline :: forall msg. Boolean -> Prop msg
+ariaMultiline = ariaAttribute "multiline" <<< show
+
+ariaMultiselectable :: forall msg. Boolean -> Prop msg
+ariaMultiselectable = ariaAttribute "multiselectable" <<< show
 
 ariaOrientation :: forall msg. String -> Prop msg
-ariaOrientation = attribute "aria-orientation"
+ariaOrientation = ariaAttribute "orientation"
+
+ariaOwns :: forall msg. String -> Prop msg
+ariaOwns = ariaAttribute "owns"
+
+ariaPlaceholder :: forall msg. String -> Prop msg
+ariaPlaceholder = ariaAttribute "placeholder"
+
+ariaPosinset :: forall msg. Int -> Prop msg
+ariaPosinset = ariaAttribute "posinset" <<< show
+
+ariaPressed :: forall msg. Boolean -> Prop msg
+ariaPressed = ariaAttribute "pressed" <<< show
+
+ariaReadonly :: forall msg. Boolean -> Prop msg
+ariaReadonly = ariaAttribute "readonly" <<< show
+
+ariaRelevant :: forall msg. String -> Prop msg
+ariaRelevant = ariaAttribute "relevant"
+
+ariaRequired :: forall msg. Boolean -> Prop msg
+ariaRequired = ariaAttribute "required" <<< show
+
+ariaRoledescription :: forall msg. String -> Prop msg
+ariaRoledescription = ariaAttribute "roledescription"
+
+ariaRowcount :: forall msg. Int -> Prop msg
+ariaRowcount = ariaAttribute "rowcount" <<< show
+
+ariaRowindex :: forall msg. Int -> Prop msg
+ariaRowindex = ariaAttribute "rowindex" <<< show
+
+ariaRowindextext :: forall msg. String -> Prop msg
+ariaRowindextext = ariaAttribute "rowindextext"
+
+ariaRowspan :: forall msg. Int -> Prop msg
+ariaRowspan = ariaAttribute "rowspan" <<< show
+
+ariaSelected :: forall msg. Boolean -> Prop msg
+ariaSelected = ariaAttribute "selected" <<< show
+
+ariaSetsize :: forall msg. Int -> Prop msg
+ariaSetsize = ariaAttribute "setsize" <<< show
+
+ariaSort :: forall msg. String -> Prop msg
+ariaSort = ariaAttribute "sort"
+
+ariaValuemax :: forall msg. Number -> Prop msg
+ariaValuemax = ariaAttribute "valuemax" <<< show
+
+ariaValuemin :: forall msg. Number -> Prop msg
+ariaValuemin = ariaAttribute "valuemin" <<< show
+
+ariaValuenow :: forall msg. Number -> Prop msg
+ariaValuenow = ariaAttribute "valuenow" <<< show
+
+ariaValuetext :: forall msg. String -> Prop msg
+ariaValuetext = ariaAttribute "valuetext"
+
+-- End ARIA attributes
+
+accept :: forall msg. String -> Prop msg
+accept = attribute "accept"
 
 autocomplete :: forall msg. String -> Prop msg
 autocomplete = attribute "autocomplete"
@@ -133,6 +343,9 @@ classes = class_ <<< joinWith " "
 classN_ :: forall msg. String -> Prop msg
 classN_ = attribute "class"
 
+contenteditable :: forall msg. String -> Prop msg
+contenteditable = attribute "contenteditable"
+
 clipRule :: forall msg. String -> Prop msg
 clipRule = attribute "clip-rule"
 
@@ -141,6 +354,9 @@ colSpan = attribute "colSpan" <<< show
 
 cRadius :: forall msg. String -> Prop msg
 cRadius = attribute "r"
+
+crossorigin :: forall msg. String -> Prop msg
+crossorigin = attribute "crossorigin"
 
 cxCoord :: forall msg. String -> Prop msg
 cxCoord = attribute "cx"
@@ -151,6 +367,9 @@ cyCoord = attribute "cy"
 data_ :: forall msg. String -> Prop msg
 data_ = attribute "data"
 
+dataCustom :: forall msg. String -> String -> Prop msg
+dataCustom key dataValue = attribute ("data-" <> key) dataValue
+
 defaultValue :: forall msg. String -> Prop msg
 defaultValue = attribute "defaultValue"
 
@@ -160,11 +379,29 @@ defer = attribute "defer"
 dims :: forall msg. String -> Prop msg
 dims = attribute "d"
 
+dir :: forall msg. String -> Prop msg
+dir = attribute "dir"
+
+dirname :: forall msg. String -> Prop msg
+dirname = attribute "dirname"
+
 disabled :: forall msg. String -> Prop msg
 disabled = attribute "disabled"
 
+draggable :: forall msg. Boolean -> Prop msg
+draggable = attribute "draggable" <<< show
+
+elementtiming :: forall msg. String -> Prop msg
+elementtiming = attribute "elementtiming"
+
 enctype :: forall msg. String -> Prop msg
 enctype = attribute "enctype"
+
+enterkeyhint :: forall msg. String -> Prop msg
+enterkeyhint = attribute "enterkeyhint"
+
+exportparts :: forall msg. String -> Prop msg
+exportparts = attribute "exportparts"
 
 fill :: forall msg. String -> Prop msg
 fill = attribute "fill"
@@ -187,14 +424,59 @@ gradientUnits = attribute "gradientUnits"
 height :: forall msg. String -> Prop msg
 height = attribute "height"
 
+hidden :: forall msg. String -> Prop msg
+hidden = attribute "hidden"
+
 href :: forall msg. String -> Prop msg
 href = attribute "href"
 
 id_ :: forall msg. String -> Prop msg
 id_ = attribute "id"
 
+inert :: forall msg. Prop msg
+inert = attribute "inert" ""
+
+inputmode :: forall msg. String -> Prop msg
+inputmode = attribute "inputmode"
+
+itemid :: forall msg. String -> Prop msg
+itemid = attribute "itemid"
+
+itemprop :: forall msg. String -> Prop msg
+itemprop = attribute "itemprop"
+
+itemref :: forall msg. String -> Prop msg
+itemref = attribute "itemref"
+
+itemscope :: forall msg. Prop msg
+itemscope = attribute "itemscope" ""
+
+itemtype :: forall msg. String -> Prop msg
+itemtype = attribute "itemtype"
+
+lang :: forall msg. String -> Prop msg
+lang = attribute "lang"
+
+nonce :: forall msg. String -> Prop msg
+nonce = attribute "nonce"
+
+max :: forall msg. String -> Prop msg
+max = attribute "max"
+
+maxlength :: forall msg. Int -> Prop msg
+maxlength = attribute "maxlength" <<< show
+
 method :: forall msg. String -> Prop msg
 method = attribute "method"
+
+min :: forall msg. String -> Prop msg
+min = attribute "min"
+
+minlength :: forall msg. Int -> Prop msg
+minlength = attribute "minlength" <<< show
+
+multiple :: forall msg. Prop msg
+multiple = attribute "multiple" ""
 
 name :: forall msg. String -> Prop msg
 name = attribute "name"
@@ -206,11 +488,26 @@ noop = attribute "" ""
 offset :: forall msg. String -> Prop msg
 offset = attribute "offset"
 
+part :: forall msg. String -> Prop msg
+part = attribute "part"
+
+pattern :: forall msg. String -> Prop msg
+pattern = attribute "pattern"
+
 placeholder :: forall msg. String -> Prop msg
 placeholder = attribute "placeholder"
 
 points :: forall msg. String -> Prop msg
 points = attribute "points"
+
+popover :: forall msg. Prop msg
+popover = attribute "popover" ""
+
+popovertarget :: forall msg. String -> Prop msg
+popovertarget = attribute "popovertarget"
+
+readonly :: forall msg. Prop msg
+readonly = attribute "readonly" ""
 
 required :: forall msg. Prop msg
 required = attribute "required" ""
@@ -227,11 +524,20 @@ rx = attribute "rx"
 selected :: forall msg. String -> Prop msg
 selected = attribute "selected"
 
+size :: forall msg. Int -> Prop msg
+size = attribute "size" <<< show
+
+slot :: forall msg. String -> Prop msg
+slot = attribute "slot"
+
 spellcheck :: forall msg. String -> Prop msg
 spellcheck = attribute "spellcheck"
 
 src :: forall msg. String -> Prop msg
 src = attribute "src"
+
+step :: forall msg. Int -> Prop msg
+step = attribute "step" <<< show
 
 stroke :: forall msg. String -> Prop msg
 stroke = attribute "stroke"
@@ -260,6 +566,9 @@ title = attribute "title"
 transform :: forall msg. String -> Prop msg
 transform = attribute "transform"
 
+translate :: forall msg. String -> Prop msg
+translate = attribute "translate"
+
 type_ :: forall msg. String -> Prop msg
 type_ = attribute "type"
 
@@ -271,6 +580,9 @@ viewBox = attribute "viewBox"
 
 width :: forall msg. String -> Prop msg
 width = attribute "width"
+
+writingsuggestions :: forall msg. Boolean -> Prop msg
+writingsuggestions = attribute "writingsuggestions" <<< show
 
 x1Coord :: forall msg. String -> Prop msg
 x1Coord = attribute "x1"

--- a/src/DOM/Erumu/HTML/Elements.purs
+++ b/src/DOM/Erumu/HTML/Elements.purs
@@ -1,74 +1,123 @@
 module DOM.Erumu.HTML.Elements
-  ( div_
-  , span
-  , br
-  , hr
+  ( ElementFn
   , a
-  , i
-  , strong
+  , abbr
+  , address
+  , area
+  , article
+  , aside
+  , audio
+  , b
+  , base
+  , bdi
+  , bdo
+  , blockquote
+  , body
+  , br
+  , button
+  , canvas
+  , caption
+  , circle
+  , cite
   , code
+  , col
+  , colgroup
+  , data_
+  , datalist
+  , dd
+  , defs
+  , del
+  , details
+  , dfn
+  , dialog
+  , div_
+  , dl
+  , dt
+  , em
+  , embed
+  , fieldset
+  , figcaption
+  , figure
+  , footer
+  , form
+  , graphic
   , h1
   , h2
   , h3
   , h4
   , h5
-  , p
-
-  , dt
-  , dd
-  , dl
-  , footer
-
-  , ol
-  , ul
-  , li
-  , section
-  , table
-  , thead
-  , tbody
-  , tr
-  , td
-  , th
-
-  , iframe
-  , object
-  , embed
-  , img
-
-  , nav
-  , main
+  , head
   , header
-  , aside
-  , legend
-
-  , label
-  , form
+  , hgroup
+  , hr
+  , html
+  , i
+  , iframe
+  , img
   , input
-  , textArea
-  , select
-  , option
-  , button
-  , time
-  , em
-  , fieldset
-
-  , address
-  , script
-  , noscript
-
-  , svg
-  , path
-  , rect
-  , graphic
-  , polygon
-  , circle
+  , ins
+  , kbd
+  , label
+  , legend
+  , li
   , line
   , linearGradient
+  , main
+  , map
+  , mark
+  , menu
+  , meta
+  , meter
+  , nav
+  , noscript
+  , object
+  , ol
+  , optgroup
+  , option
+  , output
+  , p
+  , path
+  , picture
+  , polygon
+  , pre
+  , progress
+  , q
+  , rect
+  , rp
+  , rt
+  , ruby
+  , s
+  , samp
+  , script
+  , search
+  , section
+  , select
+  , slot
+  , small
+  , source
+  , span
   , stop
+  , strong
+  , sub
+  , summary
+  , sup
+  , svg
+  , table
+  , tbody
+  , td
+  , template
   , text
-  , defs
-
-  , ElementFn
+  , textArea
+  , th
+  , thead
+  , time
+  , tr
+  , track
+  , u
+  , ul
+  , var
+  , video
+  , wbr
   ) where
 
 import Prelude
@@ -120,6 +169,72 @@ code = element "code"
 a :: forall msg. ElementFn msg
 a = element "a"
 
+abbr :: forall msg. ElementFn msg
+abbr = element "abbr"
+
+area :: forall msg. ElementFn msg
+area = element "area"
+
+article :: forall msg. ElementFn msg
+article = element "article"
+
+audio :: forall msg. ElementFn msg
+audio = element "audio"
+
+b :: forall msg. ElementFn msg
+b = element "b"
+
+base :: forall msg. ElementFn msg
+base = element "base"
+
+bdi :: forall msg. ElementFn msg
+bdi = element "bdi"
+
+bdo :: forall msg. ElementFn msg
+bdo = element "bdo"
+
+blockquote :: forall msg. ElementFn msg
+blockquote = element "blockquote"
+
+body :: forall msg. ElementFn msg
+body = element "body"
+
+canvas :: forall msg. ElementFn msg
+canvas = element "canvas"
+
+caption :: forall msg. ElementFn msg
+caption = element "caption"
+
+cite :: forall msg. ElementFn msg
+cite = element "cite"
+
+col :: forall msg. ElementFn msg
+col = element "col"
+
+colgroup :: forall msg. ElementFn msg
+colgroup = element "colgroup"
+
+data_ :: forall msg. ElementFn msg
+data_ = element "data"
+
+datalist :: forall msg. ElementFn msg
+datalist = element "datalist"
+
+del :: forall msg. ElementFn msg
+del = element "del"
+
+details :: forall msg. ElementFn msg
+details = element "details"
+
+dfn :: forall msg. ElementFn msg
+dfn = element "dfn"
+
+dialog :: forall msg. ElementFn msg
+dialog = element "dialog"
+
+ins :: forall msg. ElementFn msg
+ins = element "ins"
+
 iframe :: forall msg. ElementFn msg
 iframe = element "iframe"
 
@@ -128,6 +243,12 @@ object = element "object"
 
 embed :: forall msg. ElementFn msg
 embed = element "embed"
+
+figcaption :: forall msg. ElementFn msg
+figcaption = element "figcaption"
+
+figure :: forall msg. ElementFn msg
+figure = element "figure"
 
 img :: forall msg. ElementFn msg
 img = element "img"
@@ -146,6 +267,30 @@ h4 = element "h4"
 
 h5 :: forall msg. ElementFn msg
 h5 = element "h5"
+
+head :: forall msg. ElementFn msg
+head = element "head"
+
+hgroup :: forall msg. ElementFn msg
+hgroup = element "hgroup"
+
+html :: forall msg. ElementFn msg
+html = element "html"
+
+kbd :: forall msg. ElementFn msg
+kbd = element "kbd"
+
+mark :: forall msg. ElementFn msg
+mark = element "mark"
+
+menu :: forall msg. ElementFn msg
+menu = element "menu"
+
+meta :: forall msg. ElementFn msg
+meta = element "meta"
+
+meter :: forall msg. ElementFn msg
+meter = element "meter"
 
 p :: forall msg. ElementFn msg
 p = element "p"
@@ -210,8 +355,65 @@ textArea = element "textarea"
 select :: forall msg. ElementFn msg
 select = element "select"
 
+optgroup :: forall msg. ElementFn msg
+optgroup = element "optgroup"
+
 option :: forall msg. ElementFn msg
 option = element "option"
+
+output :: forall msg. ElementFn msg
+output = element "output"
+
+picture :: forall msg. ElementFn msg
+picture = element "picture"
+
+pre :: forall msg. ElementFn msg
+pre = element "pre"
+
+progress :: forall msg. ElementFn msg
+progress = element "progress"
+
+q :: forall msg. ElementFn msg
+q = element "q"
+
+rp :: forall msg. ElementFn msg
+rp = element "rp"
+
+rt :: forall msg. ElementFn msg
+rt = element "rt"
+
+ruby :: forall msg. ElementFn msg
+ruby = element "ruby"
+
+s :: forall msg. ElementFn msg
+s = element "s"
+
+samp :: forall msg. ElementFn msg
+samp = element "samp"
+
+search :: forall msg. ElementFn msg
+search = element "search"
+
+slot :: forall msg. ElementFn msg
+slot = element "slot"
+
+small :: forall msg. ElementFn msg
+small = element "small"
+
+source :: forall msg. ElementFn msg
+source = element "source"
+
+sub :: forall msg. ElementFn msg
+sub = element "sub"
+
+summary :: forall msg. ElementFn msg
+summary = element "summary"
+
+sup :: forall msg. ElementFn msg
+sup = element "sup"
+
+template :: forall msg. ElementFn msg
+template = element "template"
 
 fieldset :: forall msg. ElementFn msg
 fieldset = element "fieldset"
@@ -221,6 +423,21 @@ button = element "button"
 
 time :: forall msg. ElementFn msg
 time = element "time"
+
+track :: forall msg. ElementFn msg
+track = element "track"
+
+u :: forall msg. ElementFn msg
+u = element "u"
+
+var :: forall msg. ElementFn msg
+var = element "var"
+
+video :: forall msg. ElementFn msg
+video = element "video"
+
+wbr :: forall msg. ElementFn msg
+wbr = element "wbr"
 
 em :: forall msg. ElementFn msg
 em = element "em"
@@ -236,6 +453,9 @@ noscript = element "noscript"
 
 main :: forall msg. ElementFn msg
 main = element "main"
+
+map :: forall msg. ElementFn msg
+map = element "map"
 
 svg :: forall msg. ElementFn msg
 svg = svgNamespacedElement "svg"

--- a/src/DOM/Erumu/HTML/Elements.purs
+++ b/src/DOM/Erumu/HTML/Elements.purs
@@ -22,7 +22,7 @@ module DOM.Erumu.HTML.Elements
   , code
   , col
   , colgroup
-  , data_
+  , dataE
   , datalist
   , dd
   , defs
@@ -92,7 +92,7 @@ module DOM.Erumu.HTML.Elements
   , search
   , section
   , select
-  , slot
+  , slotE
   , small
   , source
   , span
@@ -214,8 +214,8 @@ col = element "col"
 colgroup :: forall msg. ElementFn msg
 colgroup = element "colgroup"
 
-data_ :: forall msg. ElementFn msg
-data_ = element "data"
+dataE :: forall msg. ElementFn msg
+dataE = element "data"
 
 datalist :: forall msg. ElementFn msg
 datalist = element "datalist"
@@ -394,8 +394,8 @@ samp = element "samp"
 search :: forall msg. ElementFn msg
 search = element "search"
 
-slot :: forall msg. ElementFn msg
-slot = element "slot"
+slotE :: forall msg. ElementFn msg
+slotE = element "slot"
 
 small :: forall msg. ElementFn msg
 small = element "small"


### PR DESCRIPTION
Initially, the intent was only to add `aria-label.` After looking at the [list of available ARIA ](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques#widget_attributes), the scope changed. After that, the scope was increased to include missing HTML elements.