### PR TITLE
[sc-50634] Erumu: Make a Way to Set a Custom Type on TextInput

### DIFF
--- a/src/DOM/Erumu/Widget/TextInput.purs
+++ b/src/DOM/Erumu/Widget/TextInput.purs
@@ -1,16 +1,17 @@
 module DOM.Erumu.Widget.TextInput
-  ( Msg
-  , Model
-  , empty
-  , withValue
-  , setValue
-  , setDisabled
+  ( Model
+  , Msg
   , disabled
-  , value
+  , empty
   , isBlank
   , render
   , renderWith
+  , renderWithType
+  , setDisabled
+  , setValue
   , update
+  , value
+  , withValue
   ) where
 
 import Prelude
@@ -70,6 +71,23 @@ renderWith liftMsg userProps (Model m) =
   let
     ourProps =
       [ type_ "text"
+      , onEventDecode "oninput" (liftMsg <<< NewInput <$> inputValue)
+      , HTML.value m.currentValue
+      ]
+  in
+    input (ourProps <> disabledProp m.disabled <> userProps) []
+
+renderWithType ::
+  forall msg.
+  String ->
+  (Msg -> msg) ->
+  Array (Prop msg) ->
+  Model ->
+  HTML msg
+renderWithType inputType liftMsg userProps (Model m) =
+  let
+    ourProps =
+      [ type_ inputType
       , onEventDecode "oninput" (liftMsg <<< NewInput <$> inputValue)
       , HTML.value m.currentValue
       ]


### PR DESCRIPTION
Adds an option to render a TextInput with a custom type. This will allow us to update the Breathmint TextField widget to render with an `email` type and display the correct keyboard on mobile devices in the login view.