### PR TITLE
[sc-50634] Erumu: Refactor Various Input Modules to Use New Input.Builder Module

### DIFF
--- a/src/DOM/Erumu/Widget/CheckboxInput.purs
+++ b/src/DOM/Erumu/Widget/CheckboxInput.purs
@@ -1,31 +1,50 @@
+-- | A checkbox input widget (`type="checkbox"`). Built on
+-- | `DOM.Erumu.Widget.Input.Builder`, its value is the `Boolean` checked state.
 module DOM.Erumu.Widget.CheckboxInput
   ( Model
   , Msg
+  , disabled
   , empty
   , fill
   , isChecked
   , render
   , renderWith
+  , setDisabled
   , update
   ) where
 
 import Prelude
 
-import DOM.Erumu.HTML (input, type_, checked)
-import DOM.Erumu.HTML.Decoder (inputChecked)
-import DOM.Erumu.Types (HTML, UpdateResult, Prop, onEventDecode, (!))
+import DOM.Erumu.Types (HTML, UpdateResult, Prop)
+import DOM.Erumu.Widget.Input.Builder as InputBuilder
 
-newtype Model = Model Boolean
-newtype Msg = Msg Boolean
+type Model = InputBuilder.Model
 
+type Msg = InputBuilder.Msg
+
+-- | An unchecked checkbox.
 empty :: Model
-empty = Model false
+empty = InputBuilder.withValue (InputBuilder.CheckboxInput false) InputBuilder.init
 
+-- | Set the checked state while preserving the input's disabled state.
+-- | A no-op for models that are not checkboxes.
 fill :: Boolean -> Model -> Model
-fill b _ = Model b
+fill b model = InputBuilder.withValue (InputBuilder.CheckboxInput b) model
 
+-- | Whether the checkbox is checked. Returns `false` for a model that is not a
+-- | checkbox.
 isChecked :: Model -> Boolean
-isChecked (Model b) = b
+isChecked model =
+  case InputBuilder.inputTypeValue model of
+    InputBuilder.CheckboxInput b -> b
+    _ -> false
+
+setDisabled :: Boolean -> Model -> Model
+setDisabled bool model =
+  InputBuilder.setDisabled bool model
+
+disabled :: Model -> Boolean
+disabled model = InputBuilder.disabled model
 
 render :: Model -> HTML Msg
 render = renderWith identity []
@@ -36,18 +55,8 @@ renderWith ::
   Array (Prop msg) ->
   Model ->
   HTML msg
-renderWith liftMsg userProps (Model m) =
-  let
-    checkedProp =
-      if m then [ checked "checked" ]
-      else []
-    ourProps =
-      [ type_ "checkbox"
-      , onEventDecode "onclick" (liftMsg <<< Msg <$> inputChecked)
-      ]
-
-  in
-    input (checkedProp <> ourProps <> userProps) []
+renderWith liftMsg userProps model =
+  InputBuilder.renderWith liftMsg userProps model
 
 update ::
   forall m.
@@ -55,4 +64,5 @@ update ::
   Msg ->
   Model ->
   UpdateResult m Model Msg
-update (Msg checked) _ = Model checked ! []
+update msg model =
+  InputBuilder.update msg model

--- a/src/DOM/Erumu/Widget/FileInput.purs
+++ b/src/DOM/Erumu/Widget/FileInput.purs
@@ -1,37 +1,60 @@
+-- | A file-picker input widget (`type="file"`). Built on
+-- | `DOM.Erumu.Widget.Input.Builder`, its value is the `FileList` the browser
+-- | reports for the chosen file(s), or `Nothing` when nothing is selected.
 module DOM.Erumu.Widget.FileInput
-  ( Msg
-  , Model(..)
+  ( Model(..)
+  , Msg
+  , disabled
   , empty
-  , withValue
-  , value
-  , setValue
   , render
   , renderWith
+  , setDisabled
+  , setValue
   , update
+  , value
+  , withValue
   ) where
 
 import Prelude
-import Data.Maybe (Maybe(..))
 
-import DOM.Erumu.HTML (input, type_)
-import DOM.Erumu.HTML.Decoder (inputFiles)
-import DOM.Erumu.Types (UpdateResult, HTML, Prop, onEventDecode, (!))
+import Data.Maybe (Maybe(..))
+import DOM.Erumu.Types (UpdateResult, HTML, Prop)
+import DOM.Erumu.Widget.Input.Builder as InputBuilder
 import Web.File.FileList (FileList)
 
-newtype Model = Model (Maybe FileList)
-newtype Msg = NewInput (Maybe FileList)
+type Model = InputBuilder.Model
 
+type Msg = InputBuilder.Msg
+
+-- | A file input with nothing selected.
 empty :: Model
-empty = withValue Nothing
+empty = InputBuilder.withValue (InputBuilder.FileInput Nothing) InputBuilder.init
 
+-- | A file input pre-populated with the given selection.
 withValue :: Maybe FileList -> Model
-withValue = Model
+withValue maybeFiles = InputBuilder.withValue (InputBuilder.FileInput maybeFiles) InputBuilder.init
 
+-- | The currently selected files, or `Nothing` when nothing is selected (or the
+-- | model is not a file input).
 value :: Model -> Maybe FileList
-value (Model fl') = fl'
+value model =
+  case InputBuilder.inputTypeValue model of
+    InputBuilder.FileInput maybeFiles -> maybeFiles
+    _ -> Nothing
 
+-- | Replace the selection. A no-op for a model that is not a file input. Preserves the input's disabled state.
 setValue :: Maybe FileList -> Model -> Model
-setValue fl' = const $ withValue fl'
+setValue maybeFiles model =
+  case InputBuilder.inputTypeValue model of
+    InputBuilder.FileInput _ -> InputBuilder.withValue (InputBuilder.FileInput maybeFiles) model
+    _ -> model
+
+setDisabled :: Boolean -> Model -> Model
+setDisabled bool model =
+  InputBuilder.setDisabled bool model
+
+disabled :: Model -> Boolean
+disabled model = InputBuilder.disabled model
 
 render :: Array (Prop Msg) -> Model -> HTML Msg
 render = renderWith identity
@@ -42,14 +65,8 @@ renderWith ::
   Array (Prop msg) ->
   Model ->
   HTML msg
-renderWith liftMsg userProps _ =
-  let
-    ourProps =
-      [ type_ "file"
-      , onEventDecode "onchange" (liftMsg <<< NewInput <$> inputFiles)
-      ]
-  in
-    input (ourProps <> userProps) []
+renderWith liftMsg userProps model =
+  InputBuilder.renderWith liftMsg userProps model
 
 update ::
   forall m.
@@ -57,4 +74,5 @@ update ::
   Msg ->
   Model ->
   UpdateResult m Model Msg
-update (NewInput newValue) _ = Model newValue ! []
+update msg model =
+  InputBuilder.update msg model

--- a/src/DOM/Erumu/Widget/Input/Builder.purs
+++ b/src/DOM/Erumu/Widget/Input/Builder.purs
@@ -1,0 +1,167 @@
+-- | The shared implementation backing the concrete input widgets
+-- | (`DOM.Erumu.Widget.TextInput`, `DOM.Erumu.Widget.FileInput`,
+-- | `DOM.Erumu.Widget.CheckboxInput`, and friends).
+-- |
+-- | A single `Model` holds the state for any flavour of `<input>` element. The
+-- | flavour is selected by the `InputTypeValue` it carries, which determines
+-- | both the rendered `type` attribute and how user interaction is decoded back
+-- | into a `Msg`. The concrete widget modules are thin wrappers that fix a
+-- | particular `InputTypeValue` and expose a type-specific API on top of this
+-- | builder.
+module DOM.Erumu.Widget.Input.Builder
+  ( InputTypeValue(..)
+  , Model
+  , Msg
+  , disabled
+  , init
+  , inputTypeValue
+  , renderWith
+  , setDisabled
+  , update
+  , withValue
+  ) where
+
+import Prelude
+
+import Data.Maybe (Maybe)
+import DOM.Erumu.HTML.Attributes (noop)
+import DOM.Erumu.HTML.Decoder (inputChecked, inputFiles, inputValue)
+import DOM.Erumu.Form (disabledProp)
+import DOM.Erumu.HTML (checked, input, type_, value)
+import DOM.Erumu.Types (HTML, UpdateResult, Prop, onEventDecode, (!))
+import Web.File.FileList (FileList)
+
+-- | The opaque state of an input widget. Construct one with `init` and refine
+-- | it with `withValue`/`setDisabled`; inspect it with `inputTypeValue`,
+-- | `disabled`, and the accessors on the concrete widget modules.
+newtype Model = Model Fields
+
+type Fields =
+  { disabled :: Boolean
+  , inputTypeValue :: InputTypeValue
+  }
+
+-- | The kind of `<input>` to render together with its current value. Each
+-- | constructor maps to an HTML `type` attribute and pairs the input with the
+-- | value type appropriate for it (a `Boolean` for checkboxes, a `FileList` for
+-- | file inputs, a `String` for the text-like inputs).
+data InputTypeValue
+  = CheckboxInput Boolean
+  | EmailInput String
+  | FileInput (Maybe FileList)
+  | TextInput String
+  | PasswordInput String
+
+-- | The builder currently does not support these flavours of `<input>`:
+-- | Button
+-- | Color
+-- | Date
+-- | DatetimeLocal
+-- | Hidden
+-- | Image
+-- | Month
+-- | Number
+-- | Radio
+-- | Range
+-- | Reset
+-- | Search
+-- | Submit
+-- | Tel
+-- | Time
+-- | Url
+-- | Week
+
+-- | An event emitted by a rendered input carrying the new value the user
+-- | produced. There is one constructor per `InputTypeValue` flavour; feeding it
+-- | to `update` folds the new value back into the `Model`.
+data Msg
+  = CheckboxMsg Boolean
+  | EmailMsg String
+  | FileMsg (Maybe FileList)
+  | TextMsg String
+  | PasswordMsg String
+
+-- | An enabled, empty text input. This is the starting point every widget's
+-- | `empty`/`withValue` constructor builds on; override the value with
+-- | `withValue` to choose a different input flavour.
+init :: Model
+init = Model
+  { disabled: false
+  , inputTypeValue: TextInput ""
+  }
+
+-- | Replace the model's input type and value. This is how a `Model` switches
+-- | between (or refreshes the value of) checkbox, email, file, text, and
+-- | password inputs. The disabled state is preserved.
+withValue :: InputTypeValue -> Model -> Model
+withValue (CheckboxInput checkedValue) (Model m) =
+  Model $ m { inputTypeValue = CheckboxInput checkedValue }
+
+withValue (EmailInput emailValue) (Model m) =
+  Model $ m { inputTypeValue = EmailInput emailValue }
+
+withValue (FileInput maybeFiles) (Model m) =
+  Model $ m { inputTypeValue = FileInput maybeFiles }
+
+withValue (TextInput textValue) (Model m) =
+  Model $ m { inputTypeValue = TextInput textValue }
+
+withValue (PasswordInput passwordValue) (Model m) =
+  Model $ m { inputTypeValue = PasswordInput passwordValue }
+
+setDisabled :: Boolean -> Model -> Model
+setDisabled bool (Model m) =
+  Model $ m { disabled = bool }
+
+disabled :: Model -> Boolean
+disabled (Model m) = m.disabled
+
+-- | The model's current input type tagged with its value. Concrete widgets
+-- | pattern match on this to project out the value in their own type.
+inputTypeValue :: Model -> InputTypeValue
+inputTypeValue (Model m) = m.inputTypeValue
+
+renderWith :: forall msg. (Msg -> msg) -> Array (Prop msg) -> Model -> HTML msg
+renderWith liftMsg userProps (Model m) =
+  let
+    ourProps =
+      case m.inputTypeValue of
+        CheckboxInput checkValue ->
+          [ type_ "checkbox"
+          , onEventDecode "onclick" (liftMsg <<< CheckboxMsg <$> inputChecked)
+          , if checkValue then (checked "checked") else noop
+          ]
+        EmailInput emailValue ->
+          [ type_ "email"
+          , onEventDecode "oninput" (liftMsg <<< EmailMsg <$> inputValue)
+          , value emailValue
+          ]
+        FileInput _fileValue ->
+          [ type_ "file"
+          , onEventDecode "onchange" (liftMsg <<< FileMsg <$> inputFiles)
+          ]
+        TextInput textValue ->
+          [ type_ "text"
+          , onEventDecode "oninput" (liftMsg <<< TextMsg <$> inputValue)
+          , value textValue
+          ]
+        PasswordInput passwordValue ->
+          [ type_ "password"
+          , onEventDecode "oninput" (liftMsg <<< PasswordMsg <$> inputValue)
+          , value passwordValue
+          ]
+
+  in
+    input (ourProps <> disabledProp m.disabled <> userProps) []
+
+update :: forall m. Applicative m => Msg -> Model -> UpdateResult m Model Msg
+update (CheckboxMsg checked) (Model m) =
+  Model (m { inputTypeValue = CheckboxInput checked }) ! []
+update (EmailMsg email) (Model m) =
+  Model (m { inputTypeValue = EmailInput email }) ! []
+update (FileMsg maybeFiles) (Model m) =
+  Model (m { inputTypeValue = FileInput maybeFiles }) ! []
+update (TextMsg text) (Model m) =
+  Model (m { inputTypeValue = TextInput text }) ! []
+update (PasswordMsg password) (Model m) =
+  Model (m { inputTypeValue = PasswordInput password }) ! []

--- a/src/DOM/Erumu/Widget/TextInput.purs
+++ b/src/DOM/Erumu/Widget/TextInput.purs
@@ -1,62 +1,87 @@
+-- | A single-line text input widget. Built on `DOM.Erumu.Widget.Input.Builder`,
+-- | it covers the three text-like input flavours that carry a `String` value:
+-- | plain text (`withValue`), email (`withEmailValue`), and password
+-- | (`withPasswordValue`). The flavour chosen at construction is preserved by
+-- | the value accessors and `setValue`.
 module DOM.Erumu.Widget.TextInput
   ( Model
   , Msg
   , disabled
   , empty
+  , fill
   , isBlank
   , render
   , renderWith
-  , renderWithType
   , setDisabled
   , setValue
   , update
   , value
+  , withEmailValue
+  , withPasswordValue
   , withValue
   ) where
 
 import Prelude
 
-import DOM.Erumu.Form (disabledProp)
-import DOM.Erumu.HTML (input, type_)
-import DOM.Erumu.HTML as HTML
-import DOM.Erumu.HTML.Decoder (inputValue)
-import DOM.Erumu.Types (UpdateResult, HTML, Prop, onEventDecode, (!))
+import DOM.Erumu.Types (HTML, Prop, UpdateResult)
+import DOM.Erumu.Widget.Input.Builder as InputBuilder
 
-newtype Model = Model Fields
+type Model = InputBuilder.Model
 
-type Fields =
-  { currentValue :: String
-  , disabled :: Boolean
-  }
+type Msg = InputBuilder.Msg
 
-newtype Msg = NewInput String
-
+-- | An empty plain-text input.
 empty :: Model
-empty = withValue ""
+empty = InputBuilder.init
 
+-- | A plain-text input pre-filled with the given value.
 withValue :: String -> Model
-withValue s =
-  Model
-    { currentValue: s
-    , disabled: false
-    }
+withValue s = InputBuilder.withValue (InputBuilder.TextInput s) InputBuilder.init
 
+-- | An email input (`type="email"`) pre-filled with the given value.
+withEmailValue :: String -> Model
+withEmailValue s = InputBuilder.withValue (InputBuilder.EmailInput s) InputBuilder.init
+
+-- | A password input (`type="password"`) pre-filled with the given value.
+withPasswordValue :: String -> Model
+withPasswordValue s = InputBuilder.withValue (InputBuilder.PasswordInput s) InputBuilder.init
+
+-- | The current string value. Returns `""` for a model that is not one of the
+-- | text-like flavours (e.g. a checkbox or file input).
 value :: Model -> String
-value (Model m) = m.currentValue
+value model =
+  case InputBuilder.inputTypeValue model of
+    InputBuilder.CheckboxInput _ -> ""
+    InputBuilder.EmailInput emailValue -> emailValue
+    InputBuilder.FileInput _ -> ""
+    InputBuilder.TextInput textValue -> textValue
+    InputBuilder.PasswordInput passwordValue -> passwordValue
 
+-- | Whether the input's value is empty.
 isBlank :: Model -> Boolean
-isBlank (Model m) = eq "" m.currentValue
+isBlank m = eq "" (value m)
 
+-- | Replace the value while preserving the input flavour and disabled state. A no-op for models
+-- | that are not text-like.
 setValue :: String -> Model -> Model
-setValue s (Model m) =
-  Model m { currentValue = s }
+setValue s model =
+  case InputBuilder.inputTypeValue model of
+    InputBuilder.CheckboxInput _ -> model
+    InputBuilder.EmailInput _ -> InputBuilder.withValue (InputBuilder.EmailInput s) model
+    InputBuilder.FileInput _ -> model
+    InputBuilder.TextInput _ -> InputBuilder.withValue (InputBuilder.TextInput s) model
+    InputBuilder.PasswordInput _ -> InputBuilder.withValue (InputBuilder.PasswordInput s) model
+
+-- | Alias for `setValue`: replace the input's value.
+fill :: String -> Model -> Model
+fill s model = setValue s model
 
 setDisabled :: Boolean -> Model -> Model
-setDisabled bool (Model m) =
-  Model m { disabled = bool }
+setDisabled bool model =
+  InputBuilder.setDisabled bool model
 
 disabled :: Model -> Boolean
-disabled (Model m) = m.disabled
+disabled model = InputBuilder.disabled model
 
 render :: Array (Prop Msg) -> Model -> HTML Msg
 render = renderWith identity
@@ -67,32 +92,8 @@ renderWith ::
   Array (Prop msg) ->
   Model ->
   HTML msg
-renderWith liftMsg userProps (Model m) =
-  let
-    ourProps =
-      [ type_ "text"
-      , onEventDecode "oninput" (liftMsg <<< NewInput <$> inputValue)
-      , HTML.value m.currentValue
-      ]
-  in
-    input (ourProps <> disabledProp m.disabled <> userProps) []
-
-renderWithType ::
-  forall msg.
-  String ->
-  (Msg -> msg) ->
-  Array (Prop msg) ->
-  Model ->
-  HTML msg
-renderWithType inputType liftMsg userProps (Model m) =
-  let
-    ourProps =
-      [ type_ inputType
-      , onEventDecode "oninput" (liftMsg <<< NewInput <$> inputValue)
-      , HTML.value m.currentValue
-      ]
-  in
-    input (ourProps <> disabledProp m.disabled <> userProps) []
+renderWith liftMsg userProps model =
+  InputBuilder.renderWith liftMsg userProps model
 
 update ::
   forall m.
@@ -100,4 +101,5 @@ update ::
   Msg ->
   Model ->
   UpdateResult m Model Msg
-update (NewInput newValue) model = setValue newValue model ! []
+update msg model =
+  InputBuilder.update msg model


### PR DESCRIPTION
This is motivated by the current need to add input types for email and password while limiting the text that can be passed to the `type_ <input-type>` attribute and avoiding repetitive copying of existing module functions like render, fill, etc.

- Adds Input.Builder module and revises TextInput, FileInput, and CheckboxInput to use the builder
- Does not add additional input types but sets the pattern to do so.
- Preserves the previous API for the three input types, minus the recently added `renderWithType` helper in favor of the `withEmailValue` and `withPasswordValue`. Those could have been named `withPasswordType` and `withEmailType,` but I chose to follow the syntax of the `withValue` helper. It could also be confusing because `withPasswordType` implied the type is Password instead of String.
